### PR TITLE
fixed red screen when no assets are returned by the asset service

### DIFF
--- a/lib/screens/dashboard/landing/wallet_portfolio.dart
+++ b/lib/screens/dashboard/landing/wallet_portfolio.dart
@@ -35,7 +35,7 @@ class WalletPortfolio extends StatelessWidget {
             builder: (context, snapshot) {
               double portfolioValue = 0;
 
-              if (snapshot.data != null || (snapshot.data ?? []).isNotEmpty) {
+              if (snapshot.data != null && (snapshot.data ?? []).isNotEmpty) {
                 portfolioValue = snapshot.data
                         ?.map((e) => e.usdPrice * double.parse(e.displayAmount))
                         .reduce((value, element) => value + element) ??


### PR DESCRIPTION
You should not see a red screen when no wallet is active or the asset service does not return any assets