### PR TITLE
Allow recovery of multi-sig from any linked account

### DIFF
--- a/lib/screens/multi_sig/multi_sig_recover_screen.dart
+++ b/lib/screens/multi_sig/multi_sig_recover_screen.dart
@@ -154,27 +154,25 @@ class _MultiSigRecoverScreenState extends State<MultiSigRecoverScreen> {
     var error = false;
     final recoverableRemoteAccounts = <String, _MultiSigAccountData>{};
 
-    if (basicAccounts.isNotEmpty) {
-      for (var basicAccount in basicAccounts) {
-        final remoteAccounts = await multiSigClient.getAccounts(
-          address: basicAccount.address,
-          coin: basicAccount.coin,
-        );
+    for (var basicAccount in basicAccounts) {
+      final remoteAccounts = await multiSigClient.getAccounts(
+        address: basicAccount.address,
+        coin: basicAccount.coin,
+      );
 
-        if (remoteAccounts == null) {
-          error = true;
-        }
+      if (remoteAccounts == null) {
+        error = true;
+      }
 
-        for (var remoteAccount in remoteAccounts ?? <MultiSigRemoteAccount>[]) {
-          final uniqueId = '${remoteAccount.remoteId}-${basicAccount.id}';
+      for (var remoteAccount in remoteAccounts ?? <MultiSigRemoteAccount>[]) {
+        final uniqueId = '${remoteAccount.remoteId}-${basicAccount.id}';
 
-          if (!multiAccountRemoteIds.contains(uniqueId) &&
-              !recoverableRemoteAccounts.containsKey(uniqueId)) {
-            recoverableRemoteAccounts[uniqueId] = _MultiSigAccountData(
-              account: remoteAccount,
-              linkedAccount: basicAccount,
-            );
-          }
+        if (!multiAccountRemoteIds.contains(uniqueId) &&
+            !recoverableRemoteAccounts.containsKey(uniqueId)) {
+          recoverableRemoteAccounts[uniqueId] = _MultiSigAccountData(
+            account: remoteAccount,
+            linkedAccount: basicAccount,
+          );
         }
       }
     }

--- a/lib/screens/multi_sig/multi_sig_recover_screen.dart
+++ b/lib/screens/multi_sig/multi_sig_recover_screen.dart
@@ -166,12 +166,11 @@ class _MultiSigRecoverScreenState extends State<MultiSigRecoverScreen> {
         }
 
         for (var remoteAccount in remoteAccounts ?? <MultiSigRemoteAccount>[]) {
-          final remoteId = remoteAccount.remoteId;
+          final uniqueId = '${remoteAccount.remoteId}-${basicAccount.id}';
 
-          if (!multiAccountRemoteIds.contains(remoteId) &&
-              !recoverableRemoteAccounts.containsKey(remoteId)) {
-            recoverableRemoteAccounts[remoteAccount.remoteId] =
-                _MultiSigAccountData(
+          if (!multiAccountRemoteIds.contains(uniqueId) &&
+              !recoverableRemoteAccounts.containsKey(uniqueId)) {
+            recoverableRemoteAccounts[uniqueId] = _MultiSigAccountData(
               account: remoteAccount,
               linkedAccount: basicAccount,
             );


### PR DESCRIPTION
Useful in the event that multiple co-signers from a multi-sig account are actually on the same device