### PR TITLE
updated pubspec to point at a version tag of provenance-dart

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -917,7 +917,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: develop
+      ref: "1.0.0"
       resolved-ref: "740c7cf1934c691a1fcea57c9838d563eb322fcd"
       url: "https://github.com/provenance-io/provenance-dart.git"
     source: git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   provenance_dart:
     git:
       url: https://github.com/provenance-io/provenance-dart.git
-      ref: develop
+      ref: 1.0.0
   provider: ^6.0.3
   qr_flutter: ^4.0.0
   rxdart: ^0.27.3


### PR DESCRIPTION
point the wallet at a specific version of the provenance-dart repo